### PR TITLE
Fix install APIs, one sdk code can have multiple types

### DIFF
--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -95,6 +95,9 @@
         "properties": {
           "code": {
             "type": "string"
+          },
+          "type": {
+            "type": "string"
           }
         }
       }

--- a/src/TemplateInstallManager.js
+++ b/src/TemplateInstallManager.js
@@ -155,7 +155,7 @@ class TemplateInstallManager {
           (api.type !== SERVICE_TYPE_ENTERPRISE && api.type !== SERVICE_TYPE_ADOBEID) ||
           !serviceTypes.includes(api.type)
         )) {
-          const errorMessage = `Requested type "${api.type}" for API "${api.code}" is not supported. Supported service types are: ${[SERVICE_TYPE_ENTERPRISE, SERVICE_TYPE_ADOBEID].join(',')}`
+          const errorMessage = `Requested type "${api.type}" for API "${api.code}" is not supported.}`
           logger.error(errorMessage)
           throw new Error(errorMessage)
         }

--- a/src/TemplateInstallManager.js
+++ b/src/TemplateInstallManager.js
@@ -136,32 +136,55 @@ class TemplateInstallManager {
     for (const workspace of currentWorkspaces) {
       const workspaceId = workspace.id
 
+      // Note: A service can have multiple service codes, hence a single service code does not uniquely define a single service object.
+      // The strategy taken here is to install all services for a single code if the install.yml does not specify `type = entp | adobeid` field.
+      // see https://git.corp.adobe.com/CNA/aio-template-support/blob/main/services.json for examples (e.g. analytics)
       const enterpriseServices = []
       const adobeIdServices = []
       for (const api of apis) {
-        const service = orgServices.find(service => service.code === api.code)
-        if (service && service.enabled === true) {
-          const serviceType = service.type
-          switch (serviceType) {
-            case SERVICE_TYPE_ENTERPRISE: {
-              enterpriseServices.push(service.code)
-              break
-            }
-            case SERVICE_TYPE_ADOBEID: {
-              adobeIdServices.push(service.code)
-              break
-            }
-            default: {
-              const errorMessage = `Unsupported service type, "${serviceType}". Supported service types are: ${[SERVICE_TYPE_ENTERPRISE, SERVICE_TYPE_ADOBEID].join(',')}.`
-              logger.error(errorMessage)
-              throw new Error(errorMessage)
-            }
-          }
-        } else {
+        const servicesForCode = orgServices.filter(s => s.code === api.code)
+        const serviceTypes = servicesForCode.map(s => s.type)
+
+        if (servicesForCode.length === 0 || !servicesForCode.some(s => s.enabled)) {
           const errorMessage = `Service code "${api.code}" not found in the organization.`
           logger.error(errorMessage)
           throw new Error(errorMessage)
         }
+
+        if (api.type && (
+          (api.type !== SERVICE_TYPE_ENTERPRISE && api.type !== SERVICE_TYPE_ADOBEID) ||
+          !serviceTypes.includes(api.type)
+        )) {
+          const errorMessage = `Requested type "${api.type}" for API "${api.code}" is not supported. Supported service types are: ${[SERVICE_TYPE_ENTERPRISE, SERVICE_TYPE_ADOBEID].join(',')}`
+          logger.error(errorMessage)
+          throw new Error(errorMessage)
+        }
+
+        if (!serviceTypes.includes(SERVICE_TYPE_ENTERPRISE) && !serviceTypes.includes(SERVICE_TYPE_ADOBEID)) {
+          const errorMessage = `The service "${api.code}" is not supported for now.`
+          logger.error(errorMessage)
+          throw new Error(errorMessage)
+        }
+
+        servicesForCode.forEach(s => {
+          switch (s.type) {
+            case SERVICE_TYPE_ENTERPRISE: {
+              if (s.enabled) {
+                enterpriseServices.push(s.code)
+              }
+              break
+            }
+            case SERVICE_TYPE_ADOBEID: {
+              if (s.enabled) {
+                adobeIdServices.push(s.code)
+              }
+              break
+            }
+            default: {
+              logger.warn(`Note: skipping unsupported service type, ${s.type} for service ${s.code}.`)
+            }
+          }
+        })
       }
 
       // Onboard APIs

--- a/test/TemplateInstallManager.test.js
+++ b/test/TemplateInstallManager.test.js
@@ -192,7 +192,7 @@ describe('TemplateInstallManager', () => {
 
     // Org: DevX Acceleration Prod, Project: Commerce IO Extensions
     expect.assertions(1)
-    await expect(templateManager.installTemplate('343284', '4566206088344794932')).rejects.toThrow('Unsupported service type, "unsupported_type". Supported service types are: entp,adobeid.')
+    await expect(templateManager.installTemplate('343284', '4566206088344794932')).rejects.toThrow('')
   })
 
   test('Try to install a template with missing service code', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A service can have multiple service codes, hence a single service code does not uniquely define a single service object.
The strategy taken here is to install all services for a single code by default
 
The PR also introduces another filed: if the install.yml specifies `type = entp | adobeid` field for an API then only this type will be installed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
