### PR TITLE
fix: add node-18 to engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "typescript": "^4.8.4"
     },
     "engines": {
-        "node": "^14 || ^16"
+        "node": "^14.18 || ^16.13 || >=18"
     },
     "devDependencies": {
         "@adobe/eslint-config-aio-lib-config": "^2.0.0",


### PR DESCRIPTION
## Motivation and Context

- update to node-18+
- update node 14, 16 to specific versions to support:
   - the node: protocol import prefix for modules (for built-in modules like fs and path), for CommonJS require. This prefix is optional in node-14 and node-16, but is mandatory in node-18.
   - private class methods
   - optional private instance class fields access
   - WeakRef 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
