### PR TITLE
fix: protect null values for license config checks, consider cred type when checking for dupe sdks

### DIFF
--- a/src/lib/configure-apis.js
+++ b/src/lib/configure-apis.js
@@ -215,7 +215,7 @@ const getWorkspaceAdobeIdCredentials = async ({ consoleClient, orgId, projectId,
  * @param {Array} params.services A list of services to get the info for.
  * @param {Array} params.productProfilesFilter A list of product profiles to filter by
  * @param {string} params.serviceType The expected service type ('entp' or 'adobeid') used to disambiguate services that appear under multiple types in the org catalog.
- * @returns {object} The services info presented as a map.
+ * @returns {Array} The services info as an array.
  */
 const getServicesInfo = async ({ consoleClient, orgId, services, productProfilesFilter, serviceType }) => {
   const orgServicesWithProductProfiles = (await consoleClient.getServicesForOrg(orgId)).body.filter(s => s.enabled)

--- a/src/lib/configure-apis.js
+++ b/src/lib/configure-apis.js
@@ -102,7 +102,7 @@ const configureAPIs = async ({ consoleClient, orgId, projectId, apis, productPro
  */
 const onboardEnterpriseApi = async ({ consoleClient, orgId, projectId, workspaceId, services, productProfiles }) => {
   const { credentialId, credentialType } = await getFirstWorkspaceCredential({ consoleClient, orgId, projectId, workspaceId })
-  const servicesInfo = await getServicesInfo({ consoleClient, orgId, services, productProfilesFilter: productProfiles })
+  const servicesInfo = await getServicesInfo({ consoleClient, orgId, services, productProfilesFilter: productProfiles, serviceType: SERVICE_TYPE_ENTERPRISE })
   await subscribeAPIS({ consoleClient, orgId, projectId, workspaceId, credentialType, credentialId, servicesInfo })
 }
 
@@ -119,7 +119,7 @@ const onboardEnterpriseApi = async ({ consoleClient, orgId, projectId, workspace
 const onboardAdobeIdApi = async ({ consoleClient, orgId, projectId, workspaceId, services }) => {
   const credentialType = SERVICE_TYPE_ADOBEID
   const credentialId = await getWorkspaceAdobeIdCredentials({ consoleClient, orgId, projectId, workspaceId })
-  const servicesInfo = await getServicesInfo({ consoleClient, orgId, services })
+  const servicesInfo = await getServicesInfo({ consoleClient, orgId, services, serviceType: SERVICE_TYPE_ADOBEID })
   await subscribeAPIS({ consoleClient, orgId, projectId, workspaceId, credentialType, credentialId, servicesInfo })
 }
 
@@ -214,18 +214,23 @@ const getWorkspaceAdobeIdCredentials = async ({ consoleClient, orgId, projectId,
  * @param {string} params.orgId The ID of the organization the project exists in.
  * @param {Array} params.services A list of services to get the info for.
  * @param {Array} params.productProfilesFilter A list of product profiles to filter by
+ * @param {string} params.serviceType The expected service type ('entp' or 'adobeid') used to disambiguate services that appear under multiple types in the org catalog.
  * @returns {object} The services info presented as a map.
  */
-const getServicesInfo = async ({ consoleClient, orgId, services, productProfilesFilter }) => {
+const getServicesInfo = async ({ consoleClient, orgId, services, productProfilesFilter, serviceType }) => {
   const orgServicesWithProductProfiles = (await consoleClient.getServicesForOrg(orgId)).body.filter(s => s.enabled)
   const servicesInfo = services.map(serviceCode => {
-    const orgServiceDefinition = orgServicesWithProductProfiles.find(os => os.code === serviceCode)
+    const orgServiceDefinition = orgServicesWithProductProfiles.find(
+      os => os.code === serviceCode && os.type === serviceType
+    )
 
     if (productProfilesFilter && productProfilesFilter.length > 0) {
       const productProfilesFilterForService = productProfilesFilter.find(p => p.sdkCode === serviceCode)?.licenseConfigs
       if (productProfilesFilterForService) {
         const filteredProductProfiles = orgServiceDefinition?.properties?.licenseConfigs?.filter(l => productProfilesFilterForService.find(productProfile => productProfile.id === l.id))
-        orgServiceDefinition.properties.licenseConfigs = filteredProductProfiles
+        if (orgServiceDefinition?.properties != null) {
+          orgServiceDefinition.properties.licenseConfigs = filteredProductProfiles
+        }
       }
     }
 

--- a/test/lib/configure-apis.test.js
+++ b/test/lib/configure-apis.test.js
@@ -314,7 +314,7 @@ describe('configureAPIs', () => {
         apis,
         productProfiles
       })
-    ).resolves.not.toThrow()
+    ).resolves.not.toBeDefined()
 
     expect(consoleClient.subscribeCredentialToServices).toHaveBeenCalledWith(
       dataMocks.project.org_id,
@@ -398,7 +398,7 @@ describe('configureAPIs', () => {
         apis,
         productProfiles
       })
-    ).resolves.not.toThrow()
+    ).resolves.not.toBeDefined()
 
     expect(consoleClient.subscribeCredentialToServices).toHaveBeenCalledTimes(1)
   })

--- a/test/lib/configure-apis.test.js
+++ b/test/lib/configure-apis.test.js
@@ -295,6 +295,114 @@ describe('configureAPIs', () => {
     )
   })
 
+  test('does not crash when productProfilesFilter targets a service whose org definition has properties: null', async () => {
+    const consoleClient = await consoleSDK.init()
+    // thirdSDK has properties: null in the mock services catalog
+    const apis = [{ code: 'thirdSDK' }]
+    const productProfiles = [
+      {
+        sdkCode: 'thirdSDK',
+        licenseConfigs: [{ id: '9999999', name: 'some config', productId: 'ZZZZZ' }]
+      }
+    ]
+
+    await expect(
+      configureAPIs({
+        consoleClient,
+        orgId: dataMocks.project.org_id,
+        projectId: dataMocks.project.id,
+        apis,
+        productProfiles
+      })
+    ).resolves.not.toThrow()
+
+    expect(consoleClient.subscribeCredentialToServices).toHaveBeenCalledWith(
+      dataMocks.project.org_id,
+      dataMocks.project.id,
+      dataMocks.workspaces[0].id,
+      dataMocks.integration.type,
+      dataMocks.integration.id,
+      expect.arrayContaining([
+        expect.objectContaining({ sdkCode: 'thirdSDK', licenseConfigs: null })
+      ])
+    )
+  })
+
+  test('enterprise path selects the entp row when a service code appears under both adobeid and entp in the org catalog', async () => {
+    const consoleClient = await consoleSDK.init()
+
+    // Catalog where dualTypeSDK appears as adobeid first (properties: null) and entp second (has licenseConfigs).
+    // Without the type-scoped find, the adobeid row would be selected and the licenseConfigs would be lost.
+    const dualTypeCatalog = [
+      {
+        name: 'Dual Type SDK',
+        code: 'dualTypeSDK',
+        enabled: true,
+        type: 'adobeid',
+        properties: null,
+        requiresApproval: false
+      },
+      {
+        name: 'Dual Type SDK',
+        code: 'dualTypeSDK',
+        enabled: true,
+        type: 'entp',
+        properties: {
+          roles: null,
+          licenseConfigs: [{ id: '1111111', name: 'entp config', productId: 'ENTP_PRODUCT', description: null }]
+        },
+        requiresApproval: false
+      }
+    ]
+    mockConsoleSDKInstance.getServicesForOrg.mockResolvedValue({ body: dualTypeCatalog })
+
+    const apis = [{ code: 'dualTypeSDK' }]
+    await configureAPIs({
+      consoleClient,
+      orgId: dataMocks.project.org_id,
+      projectId: dataMocks.project.id,
+      apis
+    })
+
+    // The entp row carries licenseConfigs — the subscription must include them.
+    expect(consoleClient.subscribeCredentialToServices).toHaveBeenCalledWith(
+      dataMocks.project.org_id,
+      dataMocks.project.id,
+      dataMocks.workspaces[0].id,
+      dataMocks.integration.type,
+      dataMocks.integration.id,
+      expect.arrayContaining([
+        expect.objectContaining({
+          sdkCode: 'dualTypeSDK',
+          licenseConfigs: [{ op: 'add', id: '1111111', productId: 'ENTP_PRODUCT' }]
+        })
+      ])
+    )
+  })
+
+  test('does not crash when productProfilesFilter contains a service code absent from the org catalog', async () => {
+    const consoleClient = await consoleSDK.init()
+    const apis = [{ code: 'AssetComputeSDK' }]
+    const productProfiles = [
+      {
+        sdkCode: 'NonExistentSDK',
+        licenseConfigs: [{ id: '0000000', name: 'ghost config', productId: 'GHOST' }]
+      }
+    ]
+
+    await expect(
+      configureAPIs({
+        consoleClient,
+        orgId: dataMocks.project.org_id,
+        projectId: dataMocks.project.id,
+        apis,
+        productProfiles
+      })
+    ).resolves.not.toThrow()
+
+    expect(consoleClient.subscribeCredentialToServices).toHaveBeenCalledTimes(1)
+  })
+
   test('creates OAuth credential and uses OAuth type when no credentials exist', async () => {
     const consoleClient = await consoleSDK.init()
     // Mock credentials to return empty array (no existing credentials)


### PR DESCRIPTION
- Do a null check on license configs property from dev console before trying to set when subscribing 
- Handle duplicate sdk codes (both adobeid and entp) when trying to set license configs 